### PR TITLE
Introduce extension API to ShellSentry

### DIFF
--- a/api/kotlin-cli-util.api
+++ b/api/kotlin-cli-util.api
@@ -37,6 +37,25 @@ public final class slack/cli/Toml {
 	public final fun parseVersion (Ljava/io/File;)Ljava/util/Map;
 }
 
+public final class slack/cli/shellsentry/AnalysisResult {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lslack/cli/shellsentry/RetrySignal;ILkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lslack/cli/shellsentry/RetrySignal;
+	public final fun component4 ()I
+	public final fun component5 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lslack/cli/shellsentry/RetrySignal;ILkotlin/jvm/functions/Function1;)Lslack/cli/shellsentry/AnalysisResult;
+	public static synthetic fun copy$default (Lslack/cli/shellsentry/AnalysisResult;Ljava/lang/String;Ljava/lang/String;Lslack/cli/shellsentry/RetrySignal;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lslack/cli/shellsentry/AnalysisResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfidence ()I
+	public final fun getExplanation ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getRetrySignal ()Lslack/cli/shellsentry/RetrySignal;
+	public final fun getThrowableMaker ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class slack/cli/shellsentry/Issue {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lslack/cli/shellsentry/RetrySignal;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lslack/cli/shellsentry/RetrySignal;Ljava/lang/String;)V
@@ -69,6 +88,11 @@ public final class slack/cli/shellsentry/IssueJsonAdapter : com/squareup/moshi/J
 	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
 	public fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class slack/cli/shellsentry/NoStacktraceThrowable : java/lang/Throwable {
+	public fun <init> (Ljava/lang/String;)V
+	public fun fillInStackTrace ()Ljava/lang/Throwable;
 }
 
 public abstract interface class slack/cli/shellsentry/RetrySignal {
@@ -122,10 +146,10 @@ public final class slack/cli/shellsentry/RetrySignal_RetryDelayedJsonAdapter : c
 
 public final class slack/cli/shellsentry/ShellSentry {
 	public static final field Companion Lslack/cli/shellsentry/ShellSentry$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;Lslack/cli/shellsentry/ShellSentryConfig;ZZZLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;Lslack/cli/shellsentry/ShellSentryConfig;ZZZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;Lslack/cli/shellsentry/ShellSentryConfig;ZZZLkotlin/jvm/functions/Function1;)Lslack/cli/shellsentry/ShellSentry;
-	public static synthetic fun copy$default (Lslack/cli/shellsentry/ShellSentry;Ljava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;Lslack/cli/shellsentry/ShellSentryConfig;ZZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lslack/cli/shellsentry/ShellSentry;
+	public fun <init> (Ljava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;Lslack/cli/shellsentry/ShellSentryConfig;ZZZLkotlin/jvm/functions/Function1;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;Lslack/cli/shellsentry/ShellSentryConfig;ZZZLkotlin/jvm/functions/Function1;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;Lslack/cli/shellsentry/ShellSentryConfig;ZZZLkotlin/jvm/functions/Function1;Ljava/util/List;)Lslack/cli/shellsentry/ShellSentry;
+	public static synthetic fun copy$default (Lslack/cli/shellsentry/ShellSentry;Ljava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;Lslack/cli/shellsentry/ShellSentryConfig;ZZZLkotlin/jvm/functions/Function1;Ljava/util/List;ILjava/lang/Object;)Lslack/cli/shellsentry/ShellSentry;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun exec ()V
 	public fun hashCode ()I
@@ -143,16 +167,18 @@ public final class slack/cli/shellsentry/ShellSentryCli : com/github/ajalt/clikt
 
 public final class slack/cli/shellsentry/ShellSentryConfig {
 	public fun <init> ()V
-	public fun <init> (ILjava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Ljava/util/List;I)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
-	public final fun copy (ILjava/lang/String;Ljava/util/List;)Lslack/cli/shellsentry/ShellSentryConfig;
-	public static synthetic fun copy$default (Lslack/cli/shellsentry/ShellSentryConfig;ILjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lslack/cli/shellsentry/ShellSentryConfig;
+	public final fun component4 ()I
+	public final fun copy (ILjava/lang/String;Ljava/util/List;I)Lslack/cli/shellsentry/ShellSentryConfig;
+	public static synthetic fun copy$default (Lslack/cli/shellsentry/ShellSentryConfig;ILjava/lang/String;Ljava/util/List;IILjava/lang/Object;)Lslack/cli/shellsentry/ShellSentryConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGradleEnterpriseServer ()Ljava/lang/String;
 	public final fun getKnownIssues ()Ljava/util/List;
+	public final fun getMinConfidence ()I
 	public final fun getVersion ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -163,5 +189,9 @@ public final class slack/cli/shellsentry/ShellSentryConfigJsonAdapter : com/squa
 	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
 	public fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class slack/cli/shellsentry/ShellSentryExtension {
+	public abstract fun check (Ljava/lang/String;IZLjava/nio/file/Path;)Lslack/cli/shellsentry/AnalysisResult;
 }
 

--- a/src/main/kotlin/slack/cli/shellsentry/Issue.kt
+++ b/src/main/kotlin/slack/cli/shellsentry/Issue.kt
@@ -84,9 +84,12 @@ constructor(
  * Base class for an issue that can be reported to Bugsnag. This is a [Throwable] for BugSnag
  * purposes but doesn't fill in a stacktrace.
  */
-internal class IssueThrowable(issue: Issue) : Throwable(issue.message) {
+public abstract class NoStacktraceThrowable(message: String) : Throwable(message) {
   override fun fillInStackTrace(): Throwable {
     // Do nothing, the stacktrace isn't relevant for these!
     return this
   }
 }
+
+/** Common [Throwable] for all [Issue]s. This is used for reporting to Bugsnag. */
+internal class KnownIssue(issue: Issue) : NoStacktraceThrowable(issue.message)

--- a/src/main/kotlin/slack/cli/shellsentry/ResultProcessor.kt
+++ b/src/main/kotlin/slack/cli/shellsentry/ResultProcessor.kt
@@ -49,6 +49,7 @@ internal class ResultProcessor(
   private val extensions: List<ShellSentryExtension> = emptyList(),
 ) {
 
+  @Suppress("LongMethod", "CyclomaticComplexMethod", "NestedBlockDepth", "ReturnCount")
   fun process(command: String, exitCode: Int, logFile: Path, isAfterRetry: Boolean): RetrySignal {
     echo("Processing CI log from ${logFile.absolutePathString()}")
 

--- a/src/main/kotlin/slack/cli/shellsentry/ResultProcessor.kt
+++ b/src/main/kotlin/slack/cli/shellsentry/ResultProcessor.kt
@@ -46,9 +46,10 @@ internal class ResultProcessor(
   private val bugsnagKey: String?,
   private val config: ShellSentryConfig,
   private val echo: (String) -> Unit,
+  private val extensions: List<ShellSentryExtension> = emptyList(),
 ) {
 
-  fun process(logFile: Path, isAfterRetry: Boolean): RetrySignal {
+  fun process(command: String, exitCode: Int, logFile: Path, isAfterRetry: Boolean): RetrySignal {
     echo("Processing CI log from ${logFile.absolutePathString()}")
 
     val bugsnag: Bugsnag? by lazy { bugsnagKey?.let { key -> createBugsnag(key) } }
@@ -62,7 +63,7 @@ internal class ResultProcessor(
         // Report to bugsnag. Shared common Throwable but with different messages.
         bugsnag?.let {
           verboseEcho("Reporting to bugsnag: $retrySignal")
-          it.notify(IssueThrowable(issue), Severity.ERROR) { report ->
+          it.notify(KnownIssue(issue), Severity.ERROR) { report ->
             // Group by the throwable message
             report.setGroupingHash(issue.groupingHash)
             report.addToTab("Run Info", "After-Retry", isAfterRetry)
@@ -82,7 +83,42 @@ internal class ResultProcessor(
       }
     }
 
-    // TODO some day log these into bugsnag too?
+    echo("No matching issues from config.json")
+    if (extensions.isNotEmpty()) {
+      echo("Checking extensions")
+      for (extension in extensions) {
+        val result = extension.check(command, exitCode, isAfterRetry, logFile) ?: continue
+
+        verboseEcho(result.message)
+        verboseEcho(result.explanation)
+
+        if (
+          result.retrySignal != RetrySignal.Unknown && result.confidence >= config.minConfidence
+        ) {
+          // Report to bugsnag. Shared common Throwable but with different messages.
+          bugsnag?.let {
+            verboseEcho("Reporting to bugsnag: ${result.retrySignal}")
+            it.notify(result.throwableMaker(result.message), Severity.ERROR) { report ->
+              report.addToTab("Run Info", "After-Retry", isAfterRetry)
+              config.gradleEnterpriseServer?.let(logLinesReversed::parseBuildScan)?.let { scanLink
+                ->
+                report.addToTab("Run Info", "Build-Scan", scanLink)
+              }
+              report.addToTab("Extensions", "Explanation", result.explanation)
+            }
+          }
+            ?: run { verboseEcho("Skipping bugsnag reporting: ${result.retrySignal}") }
+
+          if (result.retrySignal is RetrySignal.Ack) {
+            echo("Acknowledging issue but cannot retry: ${result.message}")
+          } else {
+            echo("Found retry signal: ${result.retrySignal}")
+          }
+          return result.retrySignal
+        }
+      }
+    }
+
     echo("No actionable items found in ${logFile.name}")
     return RetrySignal.Unknown
   }

--- a/src/main/kotlin/slack/cli/shellsentry/ShellSentryConfig.kt
+++ b/src/main/kotlin/slack/cli/shellsentry/ShellSentryConfig.kt
@@ -29,6 +29,11 @@ public data class ShellSentryConfig(
   @Json(name = "known_issues")
   val knownIssues: List<Issue> =
     KnownIssues::class.declaredMemberProperties.map { it.get(KnownIssues) as Issue },
+  /**
+   * A minimum confidence level on a scale of [0-100] to accept. [AnalysisResult]s from
+   * [ShellSentryExtension]s with lower confidence than this will be discarded.
+   */
+  @Json(name = "min_confidence") val minConfidence: Int = 75
 ) {
   init {
     check(version == CURRENT_VERSION) {

--- a/src/main/kotlin/slack/cli/shellsentry/ShellSentryExtension.kt
+++ b/src/main/kotlin/slack/cli/shellsentry/ShellSentryExtension.kt
@@ -37,7 +37,7 @@ import java.nio.file.Path
  * }
  * ```
  */
-public interface ShellSentryExtension {
+public fun interface ShellSentryExtension {
   /**
    * Returns a result of this extension's analysis. Returns null if this extension could not handle
    * failure.

--- a/src/main/kotlin/slack/cli/shellsentry/ShellSentryExtension.kt
+++ b/src/main/kotlin/slack/cli/shellsentry/ShellSentryExtension.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.cli.shellsentry
+
+import java.nio.file.Path
+
+/**
+ * [ShellSentryExtension] is an extension API to bring your own, complex checkers to [ShellSentry].
+ *
+ * Extensions are given the command, exit code, and console output of the failed command. They can
+ * then process it however they want and return an [AnalysisResult] if they find an issue.
+ *
+ * ## Example
+ *
+ * Below is an example of an extension that asks an AI chat bot to diagnose a failure.
+ *
+ * ```kotlin
+ * public class AiExtension(private val aiClient: AiClient) : ShellSentryExtension {
+ *   override fun check(command: String, exitCode: Int, isAfterRetry: Boolean, consoleOutput: Path): AnalysisResult? {
+ *     val text = consoleOutput.readText()
+ *     val rawAnalysis = aiClient.analyze(text)
+ *     return rawAnalysis.toAnalysisResult()
+ *   }
+ * }
+ * ```
+ */
+public interface ShellSentryExtension {
+  /**
+   * Returns a result of this extension's analysis. Returns null if this extension could not handle
+   * failure.
+   *
+   * @param command the command that was executed.
+   * @param exitCode the exit code of the command. Guaranteed to be non-zero.
+   * @param isAfterRetry whether this is after a retry.
+   * @param consoleOutput the path to the console output of the command.
+   * @see AnalysisResult for more details on what goes in a result.
+   */
+  public fun check(
+    command: String,
+    exitCode: Int,
+    isAfterRetry: Boolean,
+    consoleOutput: Path
+  ): AnalysisResult?
+}
+
+/** A returned analysis result in a [ShellSentryExtension]. */
+public data class AnalysisResult(
+  /**
+   * A broad single-line description of the error without specifying exact details, suitable for
+   * crash reporter grouping.
+   */
+  val message: String,
+  /** A detailed, multi-line message explaining the error and suggesting a solution. */
+  val explanation: String,
+  /** A [RetrySignal] indicating if this can be retried. */
+  val retrySignal: RetrySignal,
+  /**
+   * A confidence level, on a scale of [0-100]. This is useful for dynamic analysis that made be
+   * subject to confidence levels, such as an AI analyzer.
+   */
+  val confidence: Int,
+  /**
+   * A function that takes the [message] and returns a [Throwable] for reporting to Bugsnag.
+   * Consider subclassing [NoStacktraceThrowable] if needed.
+   */
+  val throwableMaker: (message: String) -> Throwable
+)

--- a/src/test/kotlin/slack/cli/shellsentry/ResultProcessorTest.kt
+++ b/src/test/kotlin/slack/cli/shellsentry/ResultProcessorTest.kt
@@ -90,7 +90,7 @@ class ResultProcessorTest {
         .trimIndent()
         .padWithTestLogs()
     )
-    val signal = newProcessor().process(outputFile.toPath(), isAfterRetry = false)
+    val signal = newProcessor().process("", 1, outputFile.toPath(), isAfterRetry = false)
     check(signal is RetrySignal.Unknown)
   }
 
@@ -102,7 +102,7 @@ class ResultProcessorTest {
       ${KnownIssues.ftlRateLimit.matchingText}
       """.trimIndent().padWithTestLogs()
     )
-    val signal = newProcessor().process(outputFile.toPath(), isAfterRetry = false)
+    val signal = newProcessor().process("", 1, outputFile.toPath(), isAfterRetry = false)
     check(signal is RetrySignal.RetryDelayed)
   }
 
@@ -114,7 +114,7 @@ class ResultProcessorTest {
       ${KnownIssues.oom.matchingText}
       """.trimIndent().padWithTestLogs()
     )
-    val signal = newProcessor().process(outputFile.toPath(), isAfterRetry = false)
+    val signal = newProcessor().process("", 1, outputFile.toPath(), isAfterRetry = false)
     check(signal is RetrySignal.RetryImmediately)
   }
 
@@ -126,7 +126,7 @@ class ResultProcessorTest {
       ${KnownIssues.fakeFailure.matchingText}
       """.trimIndent().padWithTestLogs()
     )
-    val signal = newProcessor().process(outputFile.toPath(), isAfterRetry = false)
+    val signal = newProcessor().process("", 1, outputFile.toPath(), isAfterRetry = false)
     check(signal is RetrySignal.Ack)
   }
 
@@ -136,7 +136,7 @@ class ResultProcessorTest {
     outputFile.writeText("""
       FAKE_FAILURE_a
       """.trimIndent().padWithTestLogs())
-    val signal = newProcessor().process(outputFile.toPath(), isAfterRetry = false)
+    val signal = newProcessor().process("", 1, outputFile.toPath(), isAfterRetry = false)
     check(signal is RetrySignal.Ack)
   }
 
@@ -146,7 +146,7 @@ class ResultProcessorTest {
     outputFile.writeText("""
       FAKE_FAILURE-a
       """.trimIndent().padWithTestLogs())
-    val signal = newProcessor().process(outputFile.toPath(), isAfterRetry = false)
+    val signal = newProcessor().process("", 1, outputFile.toPath(), isAfterRetry = false)
     check(signal is RetrySignal.Unknown)
   }
 


### PR DESCRIPTION
This introduces a new extension API to `ShellSentry` that allows for consumers to bring custom implementations of their own checks to the existing config-defined issues. This allows more advanced and dynamic use-cases, such as an AI-powered log processor.

The general design is described in the docs in `ShellSentryExtension.kt`.

Some other things along the way include
- Adding a `min_confidence` threshold to `ShellSentryConfig` for these checks, allowing them to indicate their confidence and more easily tune whether or not to use their results.
- Rename `IssueThrowable` to `KnownIssue` for clarity and extract a base Throwable class for the shared fillInStackTrace logic.