### PR TITLE
Add rules to lint baseline merging output + pretty print

### DIFF
--- a/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
+++ b/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
@@ -99,20 +99,19 @@ public class LintBaselineMergerCli : CliktCommand("Merges multiple lint baseline
         .toSortedMap()
 
     if (verbose) println("Gathering rules")
-    val rules = issues.keys
-      .map { issue ->
-        ReportingDescriptor(
-          id = issue.id,
-          name = issue.id,
-          shortDescription = MultiformatMessageString(text = issue.message),
-          fullDescription = MultiformatMessageString(text = issue.message),
-          defaultConfiguration = ReportingConfiguration(level = Level.Error)
-        )
-      }
-      .sortedBy { it.id }
-    val ruleIndices = rules.withIndex().associate { (index, rule) ->
-      rule.id to index.toLong()
-    }
+    val rules =
+      issues.keys
+        .map { issue ->
+          ReportingDescriptor(
+            id = issue.id,
+            name = issue.id,
+            shortDescription = MultiformatMessageString(text = issue.message),
+            fullDescription = MultiformatMessageString(text = issue.message),
+            defaultConfiguration = ReportingConfiguration(level = Level.Error)
+          )
+        }
+        .sortedBy { it.id }
+    val ruleIndices = rules.withIndex().associate { (index, rule) -> rule.id to index.toLong() }
 
     if (verbose) println("Writing to $outputFile")
     outputFile.deleteIfExists()

--- a/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
+++ b/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
@@ -142,7 +142,12 @@ public class LintBaselineMergerCli : CliktCommand("Merges multiple lint baseline
             )
           )
       )
-    Json.encodeToString(SarifSchema210.serializer(), outputSarif).let { outputFile.writeText(it) }
+    Json {
+        prettyPrint = true
+        prettyPrintIndent = "  "
+      }
+      .encodeToString(SarifSchema210.serializer(), outputSarif)
+      .let { outputFile.writeText(it) }
   }
 
   /**

--- a/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
+++ b/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
@@ -46,6 +46,7 @@ import kotlin.io.path.name
 import kotlin.io.path.readText
 import kotlin.io.path.relativeTo
 import kotlin.io.path.writeText
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -70,6 +71,12 @@ public class LintBaselineMergerCli : CliktCommand("Merges multiple lint baseline
   private val outputFile by option("--output-file", "-o").path(canBeDir = false).required()
 
   private val verbose by option("--verbose", "-v").flag()
+
+  @OptIn(ExperimentalSerializationApi::class)
+  private val json = Json {
+    prettyPrint = true
+    prettyPrintIndent = "  "
+  }
 
   override fun run() {
     val xml = XML { defaultPolicy { ignoreUnknownChildren() } }
@@ -142,12 +149,8 @@ public class LintBaselineMergerCli : CliktCommand("Merges multiple lint baseline
             )
           )
       )
-    Json {
-        prettyPrint = true
-        prettyPrintIndent = "  "
-      }
-      .encodeToString(SarifSchema210.serializer(), outputSarif)
-      .let { outputFile.writeText(it) }
+
+    json.encodeToString(SarifSchema210.serializer(), outputSarif).let { outputFile.writeText(it) }
   }
 
   /**


### PR DESCRIPTION
This adds a simple representation of identified rules + includes their `ruleIndex` in the results JSON. This also configures kotlinx-serialization to pretty print it.