### PR TITLE
Don't use absolutePathString in line baselines

### DIFF
--- a/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
+++ b/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
@@ -227,7 +227,7 @@ public class LintBaselineMergerCli : CliktCommand("Merges multiple lint baseline
   }
 
   private fun LintIssues.LintIssue.toLocation(projectPath: Path): Location {
-    val uri = projectPath.resolve(location.file).relativeTo(projectDir).absolutePathString()
+    val uri = projectPath.resolve(location.file).relativeTo(projectDir).toString()
     return Location(
       physicalLocation =
         PhysicalLocation(
@@ -249,4 +249,14 @@ public class LintBaselineMergerCli : CliktCommand("Merges multiple lint baseline
         )
     )
   }
+}
+
+public fun main() {
+  LintBaselineMergerCli().main(
+    arrayOf(
+      "--project-dir", "/Users/zacsweers/dev/slack/android3",
+      "--baseline-file-name", "lint-baseline.xml",
+      "--output-file", "/Users/zacsweers/dev/slack/oss/kotlin-cli-util/lint-baseline-merged.sarif",
+    )
+  )
 }

--- a/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
+++ b/src/main/kotlin/slack/cli/lint/LintBaselineMergerCli.kt
@@ -38,7 +38,6 @@ import io.github.detekt.sarif4k.Tool
 import io.github.detekt.sarif4k.ToolComponent
 import io.github.detekt.sarif4k.Version
 import java.nio.file.Path
-import kotlin.io.path.absolutePathString
 import kotlin.io.path.createFile
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.deleteIfExists
@@ -249,14 +248,4 @@ public class LintBaselineMergerCli : CliktCommand("Merges multiple lint baseline
         )
     )
   }
-}
-
-public fun main() {
-  LintBaselineMergerCli().main(
-    arrayOf(
-      "--project-dir", "/Users/zacsweers/dev/slack/android3",
-      "--baseline-file-name", "lint-baseline.xml",
-      "--output-file", "/Users/zacsweers/dev/slack/oss/kotlin-cli-util/lint-baseline-merged.sarif",
-    )
-  )
 }


### PR DESCRIPTION
Turns out this did always resolve an absolute path even if the path was relative initially. Oops