### PR TITLE
Add Keyable support

### DIFF
--- a/api/kotlin-cli-util.api
+++ b/api/kotlin-cli-util.api
@@ -357,7 +357,7 @@ public final class slack/cli/buildkite/Block$StringValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/BlockStep {
+public final class slack/cli/buildkite/BlockStep : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/BlockStep$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Lslack/cli/buildkite/BlockedState;Lslack/cli/buildkite/SimpleStringValue;Lslack/cli/buildkite/DependsOn;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lslack/cli/buildkite/BlockType;)V
@@ -388,7 +388,7 @@ public final class slack/cli/buildkite/BlockStep {
 	public final fun getFields ()Ljava/util/List;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getIdentifier ()Ljava/lang/String;
-	public final fun getKey ()Ljava/lang/String;
+	public fun getKey ()Ljava/lang/String;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPrompt ()Ljava/lang/String;
@@ -498,7 +498,7 @@ public final class slack/cli/buildkite/BuildType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/CommandStep {
+public final class slack/cli/buildkite/CommandStep : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/CommandStep$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Lslack/cli/buildkite/BlockedState;Lslack/cli/buildkite/SimpleStringValue;Lslack/cli/buildkite/DependsOn;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lslack/cli/buildkite/StepType;Lslack/cli/buildkite/Agents;Lslack/cli/buildkite/SimpleStringValue;Ljava/lang/Boolean;Lslack/cli/buildkite/Commands;Lslack/cli/buildkite/Commands;Ljava/lang/Long;Ljava/lang/String;Lslack/cli/buildkite/ConcurrencyMethod;Ljava/util/Map;Lslack/cli/buildkite/MatrixUnion;Ljava/util/List;Ljava/lang/Long;Lslack/cli/buildkite/Plugins;Ljava/lang/Long;Lslack/cli/buildkite/Retry;Lslack/cli/buildkite/Signature;Lslack/cli/buildkite/Skip;Lslack/cli/buildkite/SoftFail;Ljava/lang/Long;Lslack/cli/buildkite/ScriptStep;Ljava/lang/Boolean;Lslack/cli/buildkite/Build;Lslack/cli/buildkite/Trigger;Lslack/cli/buildkite/Input;Ljava/lang/Boolean;Lslack/cli/buildkite/Wait;Lslack/cli/buildkite/Wait;)V
@@ -568,7 +568,7 @@ public final class slack/cli/buildkite/CommandStep {
 	public final fun getId ()Ljava/lang/String;
 	public final fun getIdentifier ()Ljava/lang/String;
 	public final fun getInput ()Lslack/cli/buildkite/Input;
-	public final fun getKey ()Ljava/lang/String;
+	public fun getKey ()Ljava/lang/String;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getMatrix ()Lslack/cli/buildkite/MatrixUnion;
 	public final fun getName ()Ljava/lang/String;
@@ -735,7 +735,10 @@ public abstract interface class slack/cli/buildkite/DependsOn {
 public final class slack/cli/buildkite/DependsOn$Companion {
 	public final fun invoke (Ljava/lang/String;)Lslack/cli/buildkite/DependsOn;
 	public final fun invoke (Ljava/util/List;)Lslack/cli/buildkite/DependsOn;
+	public final fun invoke (Lslack/cli/buildkite/Keyable;)Lslack/cli/buildkite/DependsOn;
 	public final fun invoke ([Ljava/lang/String;)Lslack/cli/buildkite/DependsOn;
+	public final fun invoke ([Lslack/cli/buildkite/Keyable;)Lslack/cli/buildkite/DependsOn;
+	public final fun invokeKeyableList (Ljava/util/List;)Lslack/cli/buildkite/DependsOn;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1159,7 +1162,7 @@ public final class slack/cli/buildkite/GithubNotification$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract interface class slack/cli/buildkite/GroupStep {
+public abstract interface class slack/cli/buildkite/GroupStep : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/GroupStep$Companion;
 }
 
@@ -1170,6 +1173,8 @@ public final class slack/cli/buildkite/GroupStep$AnythingArrayValue : slack/cli/
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lkotlinx/serialization/json/JsonArray;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lkotlinx/serialization/json/JsonArray;Lkotlinx/serialization/json/JsonArray;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lkotlinx/serialization/json/JsonArray;)Ljava/lang/String;
 	public final fun getValue ()Lkotlinx/serialization/json/JsonArray;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lkotlinx/serialization/json/JsonArray;)I
@@ -1193,13 +1198,15 @@ public final class slack/cli/buildkite/GroupStep$AnythingArrayValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/GroupStep$BlockStepValue : slack/cli/buildkite/GroupStep {
+public final class slack/cli/buildkite/GroupStep$BlockStepValue : slack/cli/buildkite/GroupStep, slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/GroupStep$BlockStepValue$Companion;
 	public static final synthetic fun box-impl (Lslack/cli/buildkite/BlockStep;)Lslack/cli/buildkite/GroupStep$BlockStepValue;
 	public static fun constructor-impl (Lslack/cli/buildkite/BlockStep;)Lslack/cli/buildkite/BlockStep;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lslack/cli/buildkite/BlockStep;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lslack/cli/buildkite/BlockStep;Lslack/cli/buildkite/BlockStep;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lslack/cli/buildkite/BlockStep;)Ljava/lang/String;
 	public final fun getValue ()Lslack/cli/buildkite/BlockStep;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lslack/cli/buildkite/BlockStep;)I
@@ -1230,6 +1237,8 @@ public final class slack/cli/buildkite/GroupStep$BoolValue : slack/cli/buildkite
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (ZLjava/lang/Object;)Z
 	public static final fun equals-impl0 (ZZ)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Z)Ljava/lang/String;
 	public final fun getValue ()Z
 	public fun hashCode ()I
 	public static fun hashCode-impl (Z)I
@@ -1253,13 +1262,15 @@ public final class slack/cli/buildkite/GroupStep$BoolValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/GroupStep$CommandStepValue : slack/cli/buildkite/GroupStep {
+public final class slack/cli/buildkite/GroupStep$CommandStepValue : slack/cli/buildkite/GroupStep, slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/GroupStep$CommandStepValue$Companion;
 	public static final synthetic fun box-impl (Lslack/cli/buildkite/CommandStep;)Lslack/cli/buildkite/GroupStep$CommandStepValue;
 	public static fun constructor-impl (Lslack/cli/buildkite/CommandStep;)Lslack/cli/buildkite/CommandStep;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lslack/cli/buildkite/CommandStep;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lslack/cli/buildkite/CommandStep;Lslack/cli/buildkite/CommandStep;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lslack/cli/buildkite/CommandStep;)Ljava/lang/String;
 	public final fun getValue ()Lslack/cli/buildkite/CommandStep;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lslack/cli/buildkite/CommandStep;)I
@@ -1303,6 +1314,8 @@ public final class slack/cli/buildkite/GroupStep$DoubleValue : slack/cli/buildki
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (DLjava/lang/Object;)Z
 	public static final fun equals-impl0 (DD)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (D)Ljava/lang/String;
 	public final fun getValue ()D
 	public fun hashCode ()I
 	public static fun hashCode-impl (D)I
@@ -1333,6 +1346,8 @@ public final class slack/cli/buildkite/GroupStep$IntegerValue : slack/cli/buildk
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (JLjava/lang/Object;)Z
 	public static final fun equals-impl0 (JJ)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (J)Ljava/lang/String;
 	public final fun getValue ()J
 	public fun hashCode ()I
 	public static fun hashCode-impl (J)I
@@ -1356,13 +1371,15 @@ public final class slack/cli/buildkite/GroupStep$IntegerValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/GroupStep$NestedBlockStepClassValue : slack/cli/buildkite/GroupStep {
+public final class slack/cli/buildkite/GroupStep$NestedBlockStepClassValue : slack/cli/buildkite/GroupStep, slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/GroupStep$NestedBlockStepClassValue$Companion;
 	public static final synthetic fun box-impl (Lslack/cli/buildkite/NestedBlockStepClass;)Lslack/cli/buildkite/GroupStep$NestedBlockStepClassValue;
 	public static fun constructor-impl (Lslack/cli/buildkite/NestedBlockStepClass;)Lslack/cli/buildkite/NestedBlockStepClass;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lslack/cli/buildkite/NestedBlockStepClass;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lslack/cli/buildkite/NestedBlockStepClass;Lslack/cli/buildkite/NestedBlockStepClass;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lslack/cli/buildkite/NestedBlockStepClass;)Ljava/lang/String;
 	public final fun getValue ()Lslack/cli/buildkite/NestedBlockStepClass;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lslack/cli/buildkite/NestedBlockStepClass;)I
@@ -1389,6 +1406,7 @@ public final class slack/cli/buildkite/GroupStep$NestedBlockStepClassValue$Compa
 public final class slack/cli/buildkite/GroupStep$NullValue : slack/cli/buildkite/GroupStep {
 	public static final field INSTANCE Lslack/cli/buildkite/GroupStep$NullValue;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getKey ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
@@ -1401,6 +1419,8 @@ public final class slack/cli/buildkite/GroupStep$StringValue : slack/cli/buildki
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Ljava/lang/String;)Ljava/lang/String;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Ljava/lang/String;)I
@@ -1424,13 +1444,15 @@ public final class slack/cli/buildkite/GroupStep$StringValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/GroupStep$WaitStepValue : slack/cli/buildkite/GroupStep {
+public final class slack/cli/buildkite/GroupStep$WaitStepValue : slack/cli/buildkite/GroupStep, slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/GroupStep$WaitStepValue$Companion;
 	public static final synthetic fun box-impl (Lslack/cli/buildkite/Wait;)Lslack/cli/buildkite/GroupStep$WaitStepValue;
 	public static fun constructor-impl (Lslack/cli/buildkite/Wait;)Lslack/cli/buildkite/Wait;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lslack/cli/buildkite/Wait;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lslack/cli/buildkite/Wait;Lslack/cli/buildkite/Wait;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lslack/cli/buildkite/Wait;)Ljava/lang/String;
 	public final fun getValue ()Lslack/cli/buildkite/Wait;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lslack/cli/buildkite/Wait;)I
@@ -1522,7 +1544,7 @@ public final class slack/cli/buildkite/Input$StringValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/InputStep {
+public final class slack/cli/buildkite/InputStep : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/InputStep$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Boolean;Lslack/cli/buildkite/SimpleStringValue;Lslack/cli/buildkite/DependsOn;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lslack/cli/buildkite/InputType;)V
@@ -1551,7 +1573,7 @@ public final class slack/cli/buildkite/InputStep {
 	public final fun getIdentifier ()Ljava/lang/String;
 	public final fun getInput ()Ljava/lang/String;
 	public final fun getInputStepIf ()Ljava/lang/String;
-	public final fun getKey ()Ljava/lang/String;
+	public fun getKey ()Ljava/lang/String;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPrompt ()Ljava/lang/String;
@@ -1631,6 +1653,10 @@ public final class slack/cli/buildkite/JsonPrimitiveSerializer : kotlinx/seriali
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/serialization/json/JsonPrimitive;)V
+}
+
+public abstract interface class slack/cli/buildkite/Keyable {
+	public abstract fun getKey ()Ljava/lang/String;
 }
 
 public final class slack/cli/buildkite/ManualClass {
@@ -1961,7 +1987,7 @@ public final class slack/cli/buildkite/MultiChannelMessage$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/NestedBlockStepClass {
+public final class slack/cli/buildkite/NestedBlockStepClass : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/NestedBlockStepClass$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Boolean;Lslack/cli/buildkite/Block;Lslack/cli/buildkite/BlockedState;Lslack/cli/buildkite/SimpleStringValue;Lslack/cli/buildkite/DependsOn;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lslack/cli/buildkite/NestedBlockStepType;Lslack/cli/buildkite/Input;Lslack/cli/buildkite/Agents;Lslack/cli/buildkite/SimpleStringValue;Ljava/lang/Boolean;Lslack/cli/buildkite/Commands;Lslack/cli/buildkite/Commands;Ljava/lang/Long;Ljava/lang/String;Lslack/cli/buildkite/ConcurrencyMethod;Lkotlinx/serialization/json/JsonObject;Lslack/cli/buildkite/MatrixUnion;Ljava/util/List;Ljava/lang/Long;Lslack/cli/buildkite/Plugins;Ljava/lang/Long;Lslack/cli/buildkite/Retry;Lslack/cli/buildkite/Signature;Lslack/cli/buildkite/Skip;Lslack/cli/buildkite/SoftFail;Ljava/lang/Long;Lslack/cli/buildkite/ScriptStep;Ljava/lang/Boolean;Lslack/cli/buildkite/Wait;Lslack/cli/buildkite/Wait;Ljava/lang/Boolean;Lslack/cli/buildkite/Build;Lslack/cli/buildkite/Trigger;Ljava/lang/String;Ljava/util/List;)V
@@ -2034,7 +2060,7 @@ public final class slack/cli/buildkite/NestedBlockStepClass {
 	public final fun getId ()Ljava/lang/String;
 	public final fun getIdentifier ()Ljava/lang/String;
 	public final fun getInput ()Lslack/cli/buildkite/Input;
-	public final fun getKey ()Ljava/lang/String;
+	public fun getKey ()Ljava/lang/String;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getMatrix ()Lslack/cli/buildkite/MatrixUnion;
 	public final fun getName ()Ljava/lang/String;
@@ -2404,7 +2430,7 @@ public final class slack/cli/buildkite/Retry$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/ScriptStep {
+public final class slack/cli/buildkite/ScriptStep : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/ScriptStep$Companion;
 	public fun <init> ()V
 	public fun <init> (Lslack/cli/buildkite/Agents;Ljava/lang/Boolean;Lslack/cli/buildkite/SimpleStringValue;Lslack/cli/buildkite/SimpleStringValue;Ljava/lang/Boolean;Lslack/cli/buildkite/SimpleStringValue;Lslack/cli/buildkite/SimpleStringValue;Ljava/lang/Long;Ljava/lang/String;Lslack/cli/buildkite/ConcurrencyMethod;Lslack/cli/buildkite/DependsOn;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lslack/cli/buildkite/MatrixUnion;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lslack/cli/buildkite/Plugins;Ljava/lang/Long;Lslack/cli/buildkite/Retry;Lslack/cli/buildkite/Signature;Lslack/cli/buildkite/Skip;Lslack/cli/buildkite/SoftFail;Ljava/lang/Long;Lslack/cli/buildkite/ScriptType;)V
@@ -2456,7 +2482,7 @@ public final class slack/cli/buildkite/ScriptStep {
 	public final fun getEnv ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getIdentifier ()Ljava/lang/String;
-	public final fun getKey ()Ljava/lang/String;
+	public fun getKey ()Ljava/lang/String;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getMatrix ()Lslack/cli/buildkite/MatrixUnion;
 	public final fun getName ()Ljava/lang/String;
@@ -2929,17 +2955,19 @@ public final class slack/cli/buildkite/SoftFailElement$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract interface class slack/cli/buildkite/Step {
+public abstract interface class slack/cli/buildkite/Step : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/Step$Companion;
 }
 
-public final class slack/cli/buildkite/Step$CommandStepValue : slack/cli/buildkite/Step {
+public final class slack/cli/buildkite/Step$CommandStepValue : slack/cli/buildkite/Keyable, slack/cli/buildkite/Step {
 	public static final field Companion Lslack/cli/buildkite/Step$CommandStepValue$Companion;
 	public static final synthetic fun box-impl (Lslack/cli/buildkite/CommandStep;)Lslack/cli/buildkite/Step$CommandStepValue;
 	public static fun constructor-impl (Lslack/cli/buildkite/CommandStep;)Lslack/cli/buildkite/CommandStep;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lslack/cli/buildkite/CommandStep;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lslack/cli/buildkite/CommandStep;Lslack/cli/buildkite/CommandStep;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lslack/cli/buildkite/CommandStep;)Ljava/lang/String;
 	public final fun getValue ()Lslack/cli/buildkite/CommandStep;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lslack/cli/buildkite/CommandStep;)I
@@ -2977,6 +3005,8 @@ public final class slack/cli/buildkite/Step$EnumValue : slack/cli/buildkite/Step
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lslack/cli/buildkite/StringStep;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lslack/cli/buildkite/StringStep;Lslack/cli/buildkite/StringStep;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lslack/cli/buildkite/StringStep;)Ljava/lang/String;
 	public final fun getValue ()Lslack/cli/buildkite/StringStep;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lslack/cli/buildkite/StringStep;)I
@@ -3000,13 +3030,15 @@ public final class slack/cli/buildkite/Step$EnumValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/Step$InputStepValue : slack/cli/buildkite/Step {
+public final class slack/cli/buildkite/Step$InputStepValue : slack/cli/buildkite/Keyable, slack/cli/buildkite/Step {
 	public static final field Companion Lslack/cli/buildkite/Step$InputStepValue$Companion;
 	public static final synthetic fun box-impl (Lslack/cli/buildkite/InputStep;)Lslack/cli/buildkite/Step$InputStepValue;
 	public static fun constructor-impl (Lslack/cli/buildkite/InputStep;)Lslack/cli/buildkite/InputStep;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lslack/cli/buildkite/InputStep;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lslack/cli/buildkite/InputStep;Lslack/cli/buildkite/InputStep;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lslack/cli/buildkite/InputStep;)Ljava/lang/String;
 	public final fun getValue ()Lslack/cli/buildkite/InputStep;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lslack/cli/buildkite/InputStep;)I
@@ -3066,7 +3098,7 @@ public final class slack/cli/buildkite/StringStep$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract interface class slack/cli/buildkite/Trigger {
+public abstract interface class slack/cli/buildkite/Trigger : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/Trigger$Companion;
 }
 
@@ -3081,6 +3113,8 @@ public final class slack/cli/buildkite/Trigger$StringValue : slack/cli/buildkite
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Ljava/lang/String;)Ljava/lang/String;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Ljava/lang/String;)I
@@ -3104,13 +3138,15 @@ public final class slack/cli/buildkite/Trigger$StringValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/Trigger$TriggerStepValue : slack/cli/buildkite/Trigger {
+public final class slack/cli/buildkite/Trigger$TriggerStepValue : slack/cli/buildkite/Keyable, slack/cli/buildkite/Trigger {
 	public static final field Companion Lslack/cli/buildkite/Trigger$TriggerStepValue$Companion;
 	public static final synthetic fun box-impl (Lslack/cli/buildkite/TriggerStep;)Lslack/cli/buildkite/Trigger$TriggerStepValue;
 	public static fun constructor-impl (Lslack/cli/buildkite/TriggerStep;)Lslack/cli/buildkite/TriggerStep;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lslack/cli/buildkite/TriggerStep;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lslack/cli/buildkite/TriggerStep;Lslack/cli/buildkite/TriggerStep;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lslack/cli/buildkite/TriggerStep;)Ljava/lang/String;
 	public final fun getValue ()Lslack/cli/buildkite/TriggerStep;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lslack/cli/buildkite/TriggerStep;)I
@@ -3134,7 +3170,7 @@ public final class slack/cli/buildkite/Trigger$TriggerStepValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/TriggerStep {
+public final class slack/cli/buildkite/TriggerStep : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/TriggerStep$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Lslack/cli/buildkite/SimpleStringValue;Lslack/cli/buildkite/Build;Lslack/cli/buildkite/DependsOn;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lslack/cli/buildkite/Skip;Lslack/cli/buildkite/SoftFail;Ljava/lang/String;Lslack/cli/buildkite/BuildType;)V
@@ -3164,7 +3200,7 @@ public final class slack/cli/buildkite/TriggerStep {
 	public final fun getDependsOn ()Lslack/cli/buildkite/DependsOn;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getIdentifier ()Ljava/lang/String;
-	public final fun getKey ()Ljava/lang/String;
+	public fun getKey ()Ljava/lang/String;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSkip ()Lslack/cli/buildkite/Skip;
@@ -3191,7 +3227,7 @@ public final class slack/cli/buildkite/TriggerStep$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract interface class slack/cli/buildkite/Wait {
+public abstract interface class slack/cli/buildkite/Wait : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/Wait$Companion;
 }
 
@@ -3202,6 +3238,7 @@ public final class slack/cli/buildkite/Wait$Companion {
 public final class slack/cli/buildkite/Wait$NullValue : slack/cli/buildkite/Wait {
 	public static final field INSTANCE Lslack/cli/buildkite/Wait$NullValue;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getKey ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
@@ -3214,6 +3251,8 @@ public final class slack/cli/buildkite/Wait$StringValue : slack/cli/buildkite/Wa
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Ljava/lang/String;)Ljava/lang/String;
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Ljava/lang/String;)I
@@ -3237,13 +3276,15 @@ public final class slack/cli/buildkite/Wait$StringValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/Wait$WaitStepValue : slack/cli/buildkite/Wait {
+public final class slack/cli/buildkite/Wait$WaitStepValue : slack/cli/buildkite/Keyable, slack/cli/buildkite/Wait {
 	public static final field Companion Lslack/cli/buildkite/Wait$WaitStepValue$Companion;
 	public static final synthetic fun box-impl (Lslack/cli/buildkite/WaitStep;)Lslack/cli/buildkite/Wait$WaitStepValue;
 	public static fun constructor-impl (Lslack/cli/buildkite/WaitStep;)Lslack/cli/buildkite/WaitStep;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lslack/cli/buildkite/WaitStep;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lslack/cli/buildkite/WaitStep;Lslack/cli/buildkite/WaitStep;)Z
+	public fun getKey ()Ljava/lang/String;
+	public static fun getKey-impl (Lslack/cli/buildkite/WaitStep;)Ljava/lang/String;
 	public final fun getValue ()Lslack/cli/buildkite/WaitStep;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lslack/cli/buildkite/WaitStep;)I
@@ -3267,7 +3308,7 @@ public final class slack/cli/buildkite/Wait$WaitStepValue$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class slack/cli/buildkite/WaitStep {
+public final class slack/cli/buildkite/WaitStep : slack/cli/buildkite/Keyable {
 	public static final field Companion Lslack/cli/buildkite/WaitStep$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lslack/cli/buildkite/DependsOn;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lslack/cli/buildkite/WaitType;Ljava/lang/String;)V
@@ -3290,7 +3331,7 @@ public final class slack/cli/buildkite/WaitStep {
 	public final fun getDependsOn ()Lslack/cli/buildkite/DependsOn;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getIdentifier ()Ljava/lang/String;
-	public final fun getKey ()Ljava/lang/String;
+	public fun getKey ()Ljava/lang/String;
 	public final fun getType ()Lslack/cli/buildkite/WaitType;
 	public final fun getWait ()Ljava/lang/String;
 	public final fun getWaitStepIf ()Ljava/lang/String;

--- a/src/main/kotlin/slack/cli/buildkite/BuildkiteDataBindings.kt
+++ b/src/main/kotlin/slack/cli/buildkite/BuildkiteDataBindings.kt
@@ -163,34 +163,46 @@ public enum class GithubNotification(public val value: String) {
 }
 
 @Serializable
-public sealed interface GroupStep {
+public sealed interface GroupStep : Keyable {
   @Serializable
   @JvmInline
-  public value class AnythingArrayValue(public val value: JsonArray) : GroupStep
+  public value class AnythingArrayValue(public val value: JsonArray) : GroupStep {
+    override val key: String? get() = null
+  }
 
-  @Serializable @JvmInline public value class BoolValue(public val value: Boolean) : GroupStep
+  @Serializable @JvmInline public value class BoolValue(public val value: Boolean) : GroupStep {
+    override val key: String? get() = null
+  }
 
-  @Serializable @JvmInline public value class DoubleValue(public val value: Double) : GroupStep
+  @Serializable @JvmInline public value class DoubleValue(public val value: Double) : GroupStep {
+    override val key: String? get() = null
+  }
 
-  @Serializable @JvmInline public value class IntegerValue(public val value: Long) : GroupStep
-
-  @Serializable
-  @JvmInline
-  public value class NestedBlockStepClassValue(public val value: NestedBlockStepClass) : GroupStep
-
-  @Serializable @JvmInline public value class WaitStepValue(public val value: Wait) : GroupStep
-
-  @Serializable
-  @JvmInline
-  public value class BlockStepValue(public val value: BlockStep) : GroupStep
+  @Serializable @JvmInline public value class IntegerValue(public val value: Long) : GroupStep {
+    override val key: String? get() = null
+  }
 
   @Serializable
   @JvmInline
-  public value class CommandStepValue(public val value: CommandStep) : GroupStep
+  public value class NestedBlockStepClassValue(public val value: NestedBlockStepClass) : GroupStep, Keyable by value
 
-  @Serializable @JvmInline public value class StringValue(public val value: String) : GroupStep
+  @Serializable @JvmInline public value class WaitStepValue(public val value: Wait) : GroupStep, Keyable by value
 
-  @Serializable public data object NullValue : GroupStep
+  @Serializable
+  @JvmInline
+  public value class BlockStepValue(public val value: BlockStep) : GroupStep, Keyable by value
+
+  @Serializable
+  @JvmInline
+  public value class CommandStepValue(public val value: CommandStep) : GroupStep, Keyable by value
+
+  @Serializable @JvmInline public value class StringValue(public val value: String) : GroupStep {
+    override val key: String? get() = null
+  }
+
+  @Serializable public data object NullValue : GroupStep {
+    override val key: String? get() = null
+  }
 
   public companion object {
     public operator fun invoke(value: JsonArray): GroupStep = AnythingArrayValue(value)
@@ -230,7 +242,7 @@ public data class NestedBlockStepClass(
   val id: String? = null,
   val identifier: String? = null,
   @SerialName("if") val stepIf: String? = null,
-  val key: String? = null,
+  override val key: String? = null,
   val label: String? = null,
   val name: String? = null,
   val prompt: String? = null,
@@ -312,7 +324,7 @@ public data class NestedBlockStepClass(
 
   /** A list of steps */
   val steps: List<Step>? = null,
-)
+) : Keyable
 
 /**
  * - Which branches will include this step in their builds
@@ -362,12 +374,12 @@ public data class BlockStep(
   val id: String? = null,
   val identifier: String? = null,
   @SerialName("if") val blockStepIf: String? = null,
-  val key: String? = null,
+  override val key: String? = null,
   val label: String? = null,
   val name: String? = null,
   val prompt: String? = null,
   val type: BlockType? = null,
-)
+) : Keyable
 
 /** The state that the build is set to when the build is blocked by this block step */
 @Serializable
@@ -395,6 +407,16 @@ public sealed interface DependsOn {
       invoke(values.toList().map(DependsOnElement::invoke))
 
     public operator fun invoke(value: List<DependsOnElement>): DependsOn = UnionArrayValue(value)
+
+    public operator fun invoke(value: Keyable): DependsOn = invoke(requireKey(value))
+
+    public operator fun invoke(vararg values: Keyable): DependsOn = invoke(*values.map { requireKey(it) }.toTypedArray())
+
+    public operator fun invoke(value: List<Keyable>): DependsOn = invoke(value.map { DependsOnElement.invoke(requireKey(it)) })
+
+    private fun requireKey(keyable: Keyable): String {
+      return requireNotNull(keyable.key) { "Key for step must not be null to depend on it: $keyable" }
+    }
   }
 }
 
@@ -559,7 +581,7 @@ public data class ScriptStep(
   val id: String? = null,
   val identifier: String? = null,
   @SerialName("if") val commandStepIf: String? = null,
-  val key: String? = null,
+  override val key: String? = null,
   val label: String? = null,
   val matrix: MatrixUnion? = null,
   val name: String? = null,
@@ -585,7 +607,7 @@ public data class ScriptStep(
   /** The number of minutes to time out a job */
   @SerialName("timeout_in_minutes") val timeoutInMinutes: Long? = null,
   val type: ScriptType? = null,
-)
+) : Keyable
 
 /**
  * Control command order, allowed values are 'ordered' (default) and 'eager'. If you use this
@@ -870,12 +892,12 @@ public data class InputStep(
 
   /** The label of the input step */
   val input: String? = null,
-  val key: String? = null,
+  override val key: String? = null,
   val label: String? = null,
   val name: String? = null,
   val prompt: String? = null,
   val type: InputType? = null,
-)
+) : Keyable
 
 @Serializable
 public enum class InputType(public val value: String) {
@@ -883,14 +905,16 @@ public enum class InputType(public val value: String) {
 }
 
 @Serializable
-public sealed interface Step {
-  @Serializable @JvmInline public value class EnumValue(public val value: StringStep) : Step
+public sealed interface Step : Keyable {
+  @Serializable @JvmInline public value class EnumValue(public val value: StringStep) : Step {
+    override val key: String? get() = null
+  }
 
   @Serializable
   @JvmInline
-  public value class CommandStepValue(public val value: CommandStep) : Step
+  public value class CommandStepValue(public val value: CommandStep) : Step, Keyable by value
 
-  @Serializable @JvmInline public value class InputStepValue(public val value: InputStep) : Step
+  @Serializable @JvmInline public value class InputStepValue(public val value: InputStep) : Step, Keyable by value
 
   public companion object {
     public operator fun invoke(value: StringStep): Step = EnumValue(value)
@@ -917,7 +941,7 @@ public data class CommandStep(
   val id: String? = null,
   val identifier: String? = null,
   @SerialName("if") val stepIf: String? = null,
-  val key: String? = null,
+  override val key: String? = null,
   val label: String? = null,
   val name: String? = null,
   val prompt: String? = null,
@@ -993,15 +1017,17 @@ public data class CommandStep(
   /** Waits for previous steps to pass before continuing */
   val wait: Wait? = null,
   val waiter: Wait? = null,
-)
+) : Keyable
 
 @Serializable
-public sealed interface Trigger {
-  @Serializable @JvmInline public value class StringValue(public val value: String) : Trigger
+public sealed interface Trigger : Keyable {
+  @Serializable @JvmInline public value class StringValue(public val value: String) : Trigger {
+    override val key: String? get() = null
+  }
 
   @Serializable
   @JvmInline
-  public value class TriggerStepValue(public val value: TriggerStep) : Trigger
+  public value class TriggerStepValue(public val value: TriggerStep) : Trigger, Keyable by value
 }
 
 @Serializable
@@ -1018,7 +1044,7 @@ public data class TriggerStep(
   val id: String? = null,
   val identifier: String? = null,
   @SerialName("if") val triggerStepIf: String? = null,
-  val key: String? = null,
+  override val key: String? = null,
   val label: String? = null,
   val name: String? = null,
   val skip: Skip? = null,
@@ -1027,7 +1053,7 @@ public data class TriggerStep(
   /** The slug of the pipeline to create a build */
   val trigger: String? = null,
   val type: BuildType? = null,
-)
+) : Keyable
 
 @Serializable
 public enum class StepType(public val value: String) {
@@ -1042,12 +1068,16 @@ public enum class StepType(public val value: String) {
 }
 
 @Serializable
-public sealed interface Wait {
-  @Serializable @JvmInline public value class StringValue(public val value: String) : Wait
+public sealed interface Wait: Keyable {
+  @Serializable @JvmInline public value class StringValue(public val value: String) : Wait {
+    override val key: String? get() = null
+  }
 
-  @Serializable @JvmInline public value class WaitStepValue(public val value: WaitStep) : Wait
+  @Serializable @JvmInline public value class WaitStepValue(public val value: WaitStep) : Wait, Keyable by value
 
-  @Serializable public data object NullValue : Wait
+  @Serializable public data object NullValue : Wait {
+    override val key: String? get() = null
+  }
 }
 
 /** Waits for previous steps to pass before continuing */
@@ -1063,10 +1093,10 @@ public data class WaitStep(
   val id: String? = null,
   val identifier: String? = null,
   @SerialName("if") val waitStepIf: String? = null,
-  val key: String? = null,
+  override val key: String? = null,
   val type: WaitType? = null,
   val waiter: String? = null,
-)
+) : Keyable
 
 @Serializable
 public enum class WaitType(public val value: String) {

--- a/src/main/kotlin/slack/cli/buildkite/BuildkiteDataBindings.kt
+++ b/src/main/kotlin/slack/cli/buildkite/BuildkiteDataBindings.kt
@@ -167,26 +167,39 @@ public sealed interface GroupStep : Keyable {
   @Serializable
   @JvmInline
   public value class AnythingArrayValue(public val value: JsonArray) : GroupStep {
-    override val key: String? get() = null
-  }
-
-  @Serializable @JvmInline public value class BoolValue(public val value: Boolean) : GroupStep {
-    override val key: String? get() = null
-  }
-
-  @Serializable @JvmInline public value class DoubleValue(public val value: Double) : GroupStep {
-    override val key: String? get() = null
-  }
-
-  @Serializable @JvmInline public value class IntegerValue(public val value: Long) : GroupStep {
-    override val key: String? get() = null
+    override val key: String?
+      get() = null
   }
 
   @Serializable
   @JvmInline
-  public value class NestedBlockStepClassValue(public val value: NestedBlockStepClass) : GroupStep, Keyable by value
+  public value class BoolValue(public val value: Boolean) : GroupStep {
+    override val key: String?
+      get() = null
+  }
 
-  @Serializable @JvmInline public value class WaitStepValue(public val value: Wait) : GroupStep, Keyable by value
+  @Serializable
+  @JvmInline
+  public value class DoubleValue(public val value: Double) : GroupStep {
+    override val key: String?
+      get() = null
+  }
+
+  @Serializable
+  @JvmInline
+  public value class IntegerValue(public val value: Long) : GroupStep {
+    override val key: String?
+      get() = null
+  }
+
+  @Serializable
+  @JvmInline
+  public value class NestedBlockStepClassValue(public val value: NestedBlockStepClass) :
+    GroupStep, Keyable by value
+
+  @Serializable
+  @JvmInline
+  public value class WaitStepValue(public val value: Wait) : GroupStep, Keyable by value
 
   @Serializable
   @JvmInline
@@ -196,12 +209,17 @@ public sealed interface GroupStep : Keyable {
   @JvmInline
   public value class CommandStepValue(public val value: CommandStep) : GroupStep, Keyable by value
 
-  @Serializable @JvmInline public value class StringValue(public val value: String) : GroupStep {
-    override val key: String? get() = null
+  @Serializable
+  @JvmInline
+  public value class StringValue(public val value: String) : GroupStep {
+    override val key: String?
+      get() = null
   }
 
-  @Serializable public data object NullValue : GroupStep {
-    override val key: String? get() = null
+  @Serializable
+  public data object NullValue : GroupStep {
+    override val key: String?
+      get() = null
   }
 
   public companion object {
@@ -410,12 +428,16 @@ public sealed interface DependsOn {
 
     public operator fun invoke(value: Keyable): DependsOn = invoke(requireKey(value))
 
-    public operator fun invoke(vararg values: Keyable): DependsOn = invoke(*values.map { requireKey(it) }.toTypedArray())
+    public operator fun invoke(vararg values: Keyable): DependsOn =
+      invoke(*values.map { requireKey(it) }.toTypedArray())
 
-    public operator fun invoke(value: List<Keyable>): DependsOn = invoke(value.map { DependsOnElement.invoke(requireKey(it)) })
+    public operator fun invoke(value: List<Keyable>): DependsOn =
+      invoke(value.map { DependsOnElement.invoke(requireKey(it)) })
 
     private fun requireKey(keyable: Keyable): String {
-      return requireNotNull(keyable.key) { "Key for step must not be null to depend on it: $keyable" }
+      return requireNotNull(keyable.key) {
+        "Key for step must not be null to depend on it: $keyable"
+      }
     }
   }
 }
@@ -906,15 +928,20 @@ public enum class InputType(public val value: String) {
 
 @Serializable
 public sealed interface Step : Keyable {
-  @Serializable @JvmInline public value class EnumValue(public val value: StringStep) : Step {
-    override val key: String? get() = null
+  @Serializable
+  @JvmInline
+  public value class EnumValue(public val value: StringStep) : Step {
+    override val key: String?
+      get() = null
   }
 
   @Serializable
   @JvmInline
   public value class CommandStepValue(public val value: CommandStep) : Step, Keyable by value
 
-  @Serializable @JvmInline public value class InputStepValue(public val value: InputStep) : Step, Keyable by value
+  @Serializable
+  @JvmInline
+  public value class InputStepValue(public val value: InputStep) : Step, Keyable by value
 
   public companion object {
     public operator fun invoke(value: StringStep): Step = EnumValue(value)
@@ -1021,8 +1048,11 @@ public data class CommandStep(
 
 @Serializable
 public sealed interface Trigger : Keyable {
-  @Serializable @JvmInline public value class StringValue(public val value: String) : Trigger {
-    override val key: String? get() = null
+  @Serializable
+  @JvmInline
+  public value class StringValue(public val value: String) : Trigger {
+    override val key: String?
+      get() = null
   }
 
   @Serializable
@@ -1068,15 +1098,22 @@ public enum class StepType(public val value: String) {
 }
 
 @Serializable
-public sealed interface Wait: Keyable {
-  @Serializable @JvmInline public value class StringValue(public val value: String) : Wait {
-    override val key: String? get() = null
+public sealed interface Wait : Keyable {
+  @Serializable
+  @JvmInline
+  public value class StringValue(public val value: String) : Wait {
+    override val key: String?
+      get() = null
   }
 
-  @Serializable @JvmInline public value class WaitStepValue(public val value: WaitStep) : Wait, Keyable by value
+  @Serializable
+  @JvmInline
+  public value class WaitStepValue(public val value: WaitStep) : Wait, Keyable by value
 
-  @Serializable public data object NullValue : Wait {
-    override val key: String? get() = null
+  @Serializable
+  public data object NullValue : Wait {
+    override val key: String?
+      get() = null
   }
 }
 

--- a/src/main/kotlin/slack/cli/buildkite/BuildkiteDataBindings.kt
+++ b/src/main/kotlin/slack/cli/buildkite/BuildkiteDataBindings.kt
@@ -432,6 +432,7 @@ public sealed interface DependsOn {
     public operator fun invoke(vararg values: Keyable): DependsOn =
       invoke(*values.map { requireKey(it) }.toTypedArray())
 
+    @JvmName("invokeKeyableList")
     public operator fun invoke(value: List<Keyable>): DependsOn =
       invoke(value.map { DependsOnElement.invoke(requireKey(it)) })
 

--- a/src/main/kotlin/slack/cli/buildkite/BuildkiteDataBindings.kt
+++ b/src/main/kotlin/slack/cli/buildkite/BuildkiteDataBindings.kt
@@ -428,6 +428,7 @@ public sealed interface DependsOn {
 
     public operator fun invoke(value: Keyable): DependsOn = invoke(requireKey(value))
 
+    @Suppress("SpreadOperator")
     public operator fun invoke(vararg values: Keyable): DependsOn =
       invoke(*values.map { requireKey(it) }.toTypedArray())
 

--- a/src/main/kotlin/slack/cli/buildkite/Keyable.kt
+++ b/src/main/kotlin/slack/cli/buildkite/Keyable.kt
@@ -1,8 +1,21 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package slack.cli.buildkite
 
-/**
- * A buildkite element that can be identified with a [key].
- */
+/** A buildkite element that can be identified with a [key]. */
 public interface Keyable {
   public val key: String?
 }

--- a/src/main/kotlin/slack/cli/buildkite/Keyable.kt
+++ b/src/main/kotlin/slack/cli/buildkite/Keyable.kt
@@ -1,0 +1,8 @@
+package slack.cli.buildkite
+
+/**
+ * A buildkite element that can be identified with a [key].
+ */
+public interface Keyable {
+  public val key: String?
+}


### PR DESCRIPTION
This allows for easier dependency management of steps on other steps, since we can just reference `Keyable` instances rather than fish out keys or track their constants separately.