### PR TITLE
Use discinctBy when deduping sarif results

### DIFF
--- a/src/main/kotlin/slack/cli/sarif/SarifUtil.kt
+++ b/src/main/kotlin/slack/cli/sarif/SarifUtil.kt
@@ -82,6 +82,7 @@ internal val Result.shallowHash: Int
   get() =
     Objects.hash(
       ruleID,
+      message.text,
       locations?.firstOrNull()?.physicalLocation?.artifactLocation?.uri,
       locations?.firstOrNull()?.physicalLocation?.region?.startLine,
       locations?.firstOrNull()?.physicalLocation?.region?.startColumn,
@@ -123,7 +124,7 @@ internal fun List<SarifSchema210>.merge(
       // Some projects produce multiple reports for different variants, so we need to
       // de-dupe.
       // Using the default distinct() function leaves duplicates, so using a custom selector
-      .distinctBy { RESULT_SORT_COMPARATOR }
+      .distinctBy { it.shallowHash }
       .also { log("Merged ${it.size} results") }
 
   // Update rule.ruleIndex to match the index in rulesToAdd

--- a/src/main/kotlin/slack/cli/sarif/SarifUtil.kt
+++ b/src/main/kotlin/slack/cli/sarif/SarifUtil.kt
@@ -123,15 +123,7 @@ internal fun List<SarifSchema210>.merge(
       // Some projects produce multiple reports for different variants, so we need to
       // de-dupe.
       // Using the default distinct() function leaves duplicates, so using a custom selector
-      .distinctBy {
-        it.ruleID +
-          it.message +
-          it.locations?.first()?.physicalLocation?.artifactLocation?.uri +
-          it.locations?.first()?.physicalLocation?.region?.startLine +
-          it.locations?.first()?.physicalLocation?.region?.startColumn +
-          it.locations?.first()?.physicalLocation?.region?.endColumn +
-          it.locations?.first()?.physicalLocation?.region?.endLine
-      }
+      .distinctBy { RESULT_SORT_COMPARATOR }
       .also { log("Merged ${it.size} results") }
 
   // Update rule.ruleIndex to match the index in rulesToAdd

--- a/src/main/kotlin/slack/cli/sarif/SarifUtil.kt
+++ b/src/main/kotlin/slack/cli/sarif/SarifUtil.kt
@@ -122,7 +122,16 @@ internal fun List<SarifSchema210>.merge(
     flatMap { it.runs.single().results.orEmpty() }
       // Some projects produce multiple reports for different variants, so we need to
       // de-dupe.
-      .distinct()
+      // Using the default distinct() function leaves duplicates, so using a custom selector
+      .distinctBy {
+        it.ruleID +
+        it.message +
+        it.locations?.first()?.physicalLocation?.artifactLocation?.uri +
+        it.locations?.first()?.physicalLocation?.region?.startLine +
+        it.locations?.first()?.physicalLocation?.region?.startColumn +
+        it.locations?.first()?.physicalLocation?.region?.endColumn +
+        it.locations?.first()?.physicalLocation?.region?.endLine
+      }
       .also { log("Merged ${it.size} results") }
 
   // Update rule.ruleIndex to match the index in rulesToAdd

--- a/src/main/kotlin/slack/cli/sarif/SarifUtil.kt
+++ b/src/main/kotlin/slack/cli/sarif/SarifUtil.kt
@@ -125,12 +125,12 @@ internal fun List<SarifSchema210>.merge(
       // Using the default distinct() function leaves duplicates, so using a custom selector
       .distinctBy {
         it.ruleID +
-        it.message +
-        it.locations?.first()?.physicalLocation?.artifactLocation?.uri +
-        it.locations?.first()?.physicalLocation?.region?.startLine +
-        it.locations?.first()?.physicalLocation?.region?.startColumn +
-        it.locations?.first()?.physicalLocation?.region?.endColumn +
-        it.locations?.first()?.physicalLocation?.region?.endLine
+          it.message +
+          it.locations?.first()?.physicalLocation?.artifactLocation?.uri +
+          it.locations?.first()?.physicalLocation?.region?.startLine +
+          it.locations?.first()?.physicalLocation?.region?.startColumn +
+          it.locations?.first()?.physicalLocation?.region?.endColumn +
+          it.locations?.first()?.physicalLocation?.region?.endLine
       }
       .also { log("Merged ${it.size} results") }
 


### PR DESCRIPTION
###  Summary
Using the default distinct leaves duplicate results in the merged sarif. Restricting the selector to a smaller subset of fields fixes the issue.


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
